### PR TITLE
매장등록: 다음주소api 및 카카오맵 api 연동

### DIFF
--- a/src/main/java/com/yum/yumyums/controller/StoreController.java
+++ b/src/main/java/com/yum/yumyums/controller/StoreController.java
@@ -126,7 +126,7 @@ public class StoreController extends ImageDefaultUrl {
     public String storeSaveSubmit(StoreDTO storeDTO, @RequestParam("storeImg") MultipartFile imgFile , HttpServletRequest request){
         HttpSession session = request.getSession();
         SellerDTO sellerDTO = (SellerDTO)session.getAttribute("loginUser");
-
+        System.out.println(storeDTO);
         if(!imgFile.isEmpty()){
             imgUrl = "seller/"+sellerDTO.getSellerId()+"/"+imgFile.getOriginalFilename();
         }
@@ -206,4 +206,5 @@ public class StoreController extends ImageDefaultUrl {
 
         return "redirect:/stores/"+storeId+"/menu";
     }
+
 }

--- a/src/main/java/com/yum/yumyums/dto/seller/StoreDTO.java
+++ b/src/main/java/com/yum/yumyums/dto/seller/StoreDTO.java
@@ -29,6 +29,8 @@ public class StoreDTO {
     private Busy busy = Busy.CROWDED;
     private int likes;
     private ImagesDTO imagesDTO;
+    private double convX;
+    private double convY;
 
     public Store dtoToEntity() {
         Store store = new Store();
@@ -42,6 +44,9 @@ public class StoreDTO {
         store.setOpenTime(openTime);
         store.setCloseTime(closeTime);
         store.setBusy(busy);
+        store.setConvX(convX);
+        store.setConvY(convY);
+
         if(imagesDTO != null){
             store.setImages(imagesDTO.dtoToEntity());
         }

--- a/src/main/java/com/yum/yumyums/entity/seller/Store.java
+++ b/src/main/java/com/yum/yumyums/entity/seller/Store.java
@@ -56,6 +56,12 @@ public class Store {
 	@JoinColumn(name = "images_id")
 	private Images images;
 
+	@Column(nullable = false)
+	private double convX;
+
+	@Column(nullable = false)
+	private double convY;
+
 	public StoreDTO entityToDto() {
 		StoreDTO storeDTO = new StoreDTO();
 		storeDTO.setStoreId(this.id);
@@ -67,6 +73,8 @@ public class Store {
 		storeDTO.setOpenTime(this.openTime);
 		storeDTO.setCloseTime(this.closeTime);
 		storeDTO.setBusy(this.busy);
+		storeDTO.setConvX(this.convX);
+		storeDTO.setConvY(this.convY);
 		
 		// Null 체크 추가 기존 작업 중인 더미데이터에는 images 값이 없어서 부득이하게 설정
 		if (this.images != null) {

--- a/src/main/resources/static/js/common/maps.js
+++ b/src/main/resources/static/js/common/maps.js
@@ -1,0 +1,82 @@
+    // 기본 위치 (강남역의 위도와 경도)
+    const DEFAULT_LAT = 37.49799;
+    const DEFAULT_LNG = 127.027912;
+
+    var mapContainer = document.getElementById('map'), // 지도를 표시할 div
+        mapOption = {
+            center: new kakao.maps.LatLng(DEFAULT_LAT, DEFAULT_LNG), // 지도의 중심좌표
+            level: 5 // 지도의 확대 레벨
+        };
+
+    // 지도를 미리 생성
+    var map = new kakao.maps.Map(mapContainer, mapOption);
+    // 주소-좌표 변환 객체를 생성
+    var geocoder = new kakao.maps.services.Geocoder();
+    // 마커를 미리 생성
+    var marker = new kakao.maps.Marker({
+        position: new kakao.maps.LatLng(DEFAULT_LAT, DEFAULT_LNG),
+        map: map
+    });
+
+    // 클라이언트의 현재 위치를 가져오는 함수
+    function getLocation() {
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(showPosition, showError);
+        } else {
+            alert("이 브라우저에서는 Geolocation을 지원하지 않습니다.");
+            showPosition({ coords: { latitude: DEFAULT_LAT, longitude: DEFAULT_LNG } });
+        }
+    }
+
+    // 위치를 가져온 후 지도를 표시하는 함수
+    function showPosition(position) {
+        var lat = position.coords.latitude; // 위도
+        var lng = position.coords.longitude; // 경도
+
+        var coords = new kakao.maps.LatLng(lat, lng);
+        map.setCenter(coords); // 지도 중심을 현재 위치로 변경
+        marker.setPosition(coords); // 마커를 현재 위치로 이동
+
+        // 위도와 경도를 입력 필드에 설정
+        document.getElementById("convX").value = lng;
+        document.getElementById("convY").value = lat;
+
+        // 주소 변환
+        geocoder.coord2Address(lng, lat, function(results, status) {
+            if (status === kakao.maps.services.Status.OK) {
+                var address = results[0].address.address_name; // 주소
+                document.getElementById("address").value = address; // 주소 값을 입력 필드에 설정
+            }
+        });
+    }
+
+    // 오류 처리 함수
+    function showError(error) {
+        switch(error.code) {
+            case error.PERMISSION_DENIED:
+                alert("사용자가 위치정보 제공을 거부했습니다.");
+                break;
+            case error.POSITION_UNAVAILABLE:
+                alert("위치정보를 사용할 수 없습니다.");
+                break;
+            case error.TIMEOUT:
+                alert("위치정보 요청이 시간 초과되었습니다.");
+                break;
+            case error.UNKNOWN_ERROR:
+                alert("알 수 없는 오류가 발생했습니다.");
+                break;
+        }
+
+        // 기본 위치로 설정
+        var coords = new kakao.maps.LatLng(DEFAULT_LAT, DEFAULT_LNG);
+        map.setCenter(coords);
+        marker.setPosition(coords);
+        document.getElementById("convX").value = DEFAULT_LNG;
+        document.getElementById("convY").value = DEFAULT_LAT;
+        document.getElementById("address").value = "서울 강남구 강남대로 지하 396"; // 기본 주소 설정
+    }
+
+    // 페이지 로드 시 위치를 가져옴
+    window.onload = function() {
+        getLocation();
+    };

--- a/src/main/resources/templates/store/save.html
+++ b/src/main/resources/templates/store/save.html
@@ -15,7 +15,7 @@
                     </div>
 
                     <div class="form-item">
-                        <label class="form-label" for="name">카테고리(업종) <sup>*</sup></label>
+                        <label class="form-label my-3" for="name">카테고리(업종) <sup>*</sup></label>
                         <select class="form-select" name="category" required>
                             <option value="" selected disabled hidden>카테고리 선택</option>
                             <option th:each="category : ${categories}"
@@ -41,9 +41,17 @@
                         <label class="form-label my-3" for="passwordChk">비밀번호 확인 <sup>*</sup></label>
                         <input type="password" class="form-control" name="passwordChk" id="passwordChk" placeholder="비밀번호 입력" disabled>
                     </div>
-                    <div class="form-item">
+                    <div class="form-item mt-3">
+                        <div class="row g-2 justify-content-center">
+                            <div id="map" class="shadow" style="width:300px;height:300px;margin-top:10px;"></div>
+                        </div>
                         <label class="form-label my-3" for="address">주소 <sup>*</sup></label>
-                        <input type="text" class="form-control" id="address" name="address" required>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <input type="text" class="form-control" id="address" name="address" readonly>
+                            <input type="button" class="btn btn-secondary py-1 px-2 w-20" onclick="sample5_execDaumPostcode()" value="주소 검색"><br>
+                            <input type="hidden" id="convX" name="convX">
+                            <input type="hidden" id="convY" name="convY">
+                        </div>
                     </div>
                     <div class="row">
                         <div class="my-3">
@@ -85,24 +93,39 @@
 
 <script src="../../js/common/duplicate.js"></script>
 <script src="../../js/common/images.js"></script>
-<!--
+
+<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=085a096f7e5948cab899f39d4bc642d1&libraries=services"></script>
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script src="../../js/common/maps.js"></script>
 <script>
-    function previewImage(event) {
-        const files = event.target.files;
-        const imagePreviewBox = $('#imagePreviewBox');
-        imagePreviewBox.empty(); // 기존 이미지를 초기화
+    function sample5_execDaumPostcode() {
+        new daum.Postcode({
+            oncomplete: function(data) {
+                var addr = data.address; // 최종 주소 변수
 
-        for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-            const reader = new FileReader();
+                // 주소 정보를 해당 필드에 넣는다.
+                document.getElementById("address").value = addr;
+                // 주소로 상세 정보를 검색
+                geocoder.addressSearch(data.address, function(results, status) {
+                    // 정상적으로 검색이 완료됐으면
+                    if (status === kakao.maps.services.Status.OK) {
 
-            reader.onload = function(e) {
-                imagePreviewBox.append(`<img src="${e.target.result}" class="col-4 p-0 shadow">`); // 이미지 추가
-            }
+                        var result = results[0]; // 첫번째 결과의 값을 활용
 
-            if (file) {
-                reader.readAsDataURL(file); // 파일을 읽어서 Data URL로 변환
-            }
+                    // 해당 주소에 대한 좌표를 받아서
+                    var coords = new kakao.maps.LatLng(result.y, result.x);
+                    document.getElementById("convX").value = result.x;
+                    document.getElementById("convY").value = result.y;
+                    // 지도를 보여준다.
+                    mapContainer.style.display = "block";
+                    map.relayout();
+                    // 지도 중심을 변경한다.
+                    map.setCenter(coords);
+                    // 마커를 결과값으로 받은 위치로 옮긴다.
+                    marker.setPosition(coords);
+                }
+            });
         }
-    }
-</script>-->
+    }).open();
+}
+</script>

--- a/src/main/resources/templates/store/save.html
+++ b/src/main/resources/templates/store/save.html
@@ -48,7 +48,7 @@
                         <label class="form-label my-3" for="address">주소 <sup>*</sup></label>
                         <div class="d-flex justify-content-between align-items-center">
                             <input type="text" class="form-control" id="address" name="address" readonly>
-                            <input type="button" class="btn btn-secondary py-1 px-2 w-20" onclick="sample5_execDaumPostcode()" value="주소 검색"><br>
+                            <input type="button" class="btn btn-secondary py-1 px-2 w-20" onclick="searchAddressSetCoords()" value="주소 검색"><br>
                             <input type="hidden" id="convX" name="convX">
                             <input type="hidden" id="convY" name="convY">
                         </div>
@@ -98,7 +98,7 @@
 <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script src="../../js/common/maps.js"></script>
 <script>
-    function sample5_execDaumPostcode() {
+    function searchAddressSetCoords() {
         new daum.Postcode({
             oncomplete: function(data) {
                 var addr = data.address; // 최종 주소 변수


### PR DESCRIPTION
### Changed
- Store 엔티티 및 DTO:  좌표 필드 추가
- maps.js : 카카오맵api 연동. 접속한 클라이언트의 현위치 혹은 강남역을 기본 세팅 
- store/save.html :  다음주소api 연동하여 주소검색 후, 해당 주소를 카카오맵 api로 검색하여 좌표값 받고 지도로 출력

### Issue number
- #50
